### PR TITLE
Add --manifest-path to commands to allow warnings to be displayed correctly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,10 +90,13 @@ fn generate_cargo_cmd(path: &PathBuf, commands: &[String]) -> Command {
 
     cargo_cmd.arg(command[0].clone());
 
+    // Clippy requires the full path to be provided for the manifest-path, so
+    // pass it across in full.
+    let full_path = std::fs::canonicalize(path).expect("Failed to expand path");
+
     // Insert the manifest-path option so that any logs about files are relative
     // to the current directory.
-    cargo_cmd.arg("--manifest-path".to_string());
-    cargo_cmd.arg(format!("{}/Cargo.toml", path.to_string_lossy()));
+    cargo_cmd.arg(format!("--manifest-path={}/Cargo.toml", full_path.to_string_lossy()));
 
     for arg in args {
         cargo_cmd.arg(arg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,10 +118,10 @@ fn main() {
         .get_matches();
 
     let commands = matches.subcommand_matches("multi")
-                          .and_then(|m| m.values_of("cmd"))
-                          .expect("No cargo commands provided")
-                          .map(|arg| arg.to_string())
-                          .collect::<Vec<_>>();
+        .and_then(|m| m.values_of("cmd"))
+        .expect("No cargo commands provided")
+        .map(|arg| arg.to_string())
+        .collect::<Vec<_>>();
 
     let banner = format!("Executing {} {}", CARGO, commands.join(" "));
 


### PR DESCRIPTION
This adds the manifest path option to commands run, this ensures that all warnings are relative to the current directory, rather than having warnings about main.rs and being unable to determine which crate has the warning was present in.